### PR TITLE
Update Network.ini for external IP change.

### DIFF
--- a/Skins/ModernGadgets/Network/Network.ini
+++ b/Skins/ModernGadgets/Network/Network.ini
@@ -140,7 +140,7 @@ DynamicVariables=1
 [MeasureExternalIp]
 Measure=Plugin
 Plugin=WebParser
-URL=https://ipv4.wtfismyip.com/text
+URL=https://api.ipify.org/
 RegExp=(?siU)^(.*)$
 StringIndex=1
 ForceReload=1


### PR DESCRIPTION
Updated External IP check to use ipify.org, as it has a better uptime history and is not blocked by most security proxies (blueCoat, etc) like wtfismyip.com is.  Its a dropin replacement.